### PR TITLE
LPS-74595 Add test for StringUtil

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
@@ -721,6 +721,14 @@ public class StringUtilTest {
 		Assert.assertEquals("hijk", lines[2]);
 		Assert.assertEquals("", lines[3]);
 		Assert.assertEquals("lmn", lines[4]);
+
+		String splitByIndentation = "    hello\n    world";
+
+		lines = StringUtil.splitLines(splitByIndentation);
+
+		Assert.assertEquals(Arrays.toString(lines), 2, lines.length);
+		Assert.assertEquals("    hello", lines[0]);
+		Assert.assertEquals("    world", lines[1]);
 	}
 
 	@Test(timeout = 1000)


### PR DESCRIPTION
Steps:
run ant test-class -Dtest.class=StringUtilTest from portal-kernal
then you will get the following error:
```    [junit] Testcase: testSplitLines(com.liferay.portal.kernel.util.StringUtilTest):	FAILED
    [junit] expected:<[    ]hello> but was:<[]hello>
    [junit] junit.framework.AssertionFailedError: expected:<[    ]hello> but was:<[]hello>
    [junit] 	at com.liferay.portal.kernel.util.StringUtilTest.testSplitLines(StringUtilTest.java:730)
    [junit] 	at com.liferay.portal.kernel.test.rule.CodeCoverageAssertor$1.evaluate(CodeCoverageAssertor.java:72)
    [junit] 
    [junit] 
```